### PR TITLE
Properly escape special characters.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "bin": "./bin/readmetree",
   "dependencies": {
     "underscore": "~1.5.1",
-    "marked": "~0.2.9"
+    "marked": "~0.2.9",
+    "special-html": "0.0.1"
   }
 }

--- a/readmetree.js
+++ b/readmetree.js
@@ -5,6 +5,7 @@ var exec = require('child_process').exec
 
 var _ = require('underscore')
 var marked = require('marked')
+var special = require('special-html')
 
 var style = fs.readFileSync(path.join(__dirname, 'assets', 'style.css'), 'utf8')
 var nav = fs.readFileSync(path.join(__dirname, 'assets', 'nav.html'), 'utf8')
@@ -39,7 +40,7 @@ readdirRecur(root, isNodeModules)
         var shortpath = readme.replace(path.dirname(path.dirname(readme)), '')
         if (content[shortpath]) return
         content[shortpath] =
-            style + nav + marked(fs.readFileSync(readme, 'utf8'))
+            style + nav + special(marked(fs.readFileSync(readme, 'utf8')))
         content['/'] +=
             '<br><a href="http://localhost:'+PORT+shortpath+'">'
             + 'http://localhost:'+PORT+'<b>'+shortpath+'</b></a>'


### PR DESCRIPTION
Fixes issues like this in some readmes:

![screen shot 2013-09-12 at 10 37 37 am](https://f.cloud.github.com/assets/569817/1127682/aa62cc10-1b43-11e3-86d3-f74739ced2c7.png)

Thanks! :)
