### PR TITLE
Add syntax highlighting

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -275,5 +275,130 @@ pre {
   pre code, pre tt {
     background-color: transparent;
     border: none; }
+/*
+github.com style (c) Vasily Polovnyov <vast@whiteants.net>
+
+*/
+
+.hljs {
+  display: block;
+  padding: 0.5em;
+  color: #333;
+  background: #f8f8f8;
+}
+
+.hljs-comment,
+.hljs-template_comment,
+.diff .hljs-header,
+.hljs-javadoc {
+  color: #998;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.css .rule .hljs-keyword,
+.hljs-winutils,
+.javascript .hljs-title,
+.nginx .hljs-title,
+.hljs-subst,
+.hljs-request,
+.hljs-status {
+  color: #333;
+  font-weight: bold;
+}
+
+.hljs-number,
+.hljs-hexcolor,
+.ruby .hljs-constant {
+  color: #099;
+}
+
+.hljs-string,
+.hljs-tag .hljs-value,
+.hljs-phpdoc,
+.tex .hljs-formula {
+  color: #d14;
+}
+
+.hljs-title,
+.hljs-id,
+.coffeescript .hljs-params,
+.scss .hljs-preprocessor {
+  color: #900;
+  font-weight: bold;
+}
+
+.javascript .hljs-title,
+.lisp .hljs-title,
+.clojure .hljs-title,
+.hljs-subst {
+  font-weight: normal;
+}
+
+.hljs-class .hljs-title,
+.haskell .hljs-type,
+.vhdl .hljs-literal,
+.tex .hljs-command {
+  color: #458;
+  font-weight: bold;
+}
+
+.hljs-tag,
+.hljs-tag .hljs-title,
+.hljs-rules .hljs-property,
+.django .hljs-tag .hljs-keyword {
+  color: #000080;
+  font-weight: normal;
+}
+
+.hljs-attribute,
+.hljs-variable,
+.lisp .hljs-body {
+  color: #008080;
+}
+
+.hljs-regexp {
+  color: #009926;
+}
+
+.hljs-symbol,
+.ruby .hljs-symbol .hljs-string,
+.lisp .hljs-keyword,
+.tex .hljs-special,
+.hljs-prompt {
+  color: #990073;
+}
+
+.hljs-built_in,
+.lisp .hljs-title,
+.clojure .hljs-built_in {
+  color: #0086b3;
+}
+
+.hljs-preprocessor,
+.hljs-pragma,
+.hljs-pi,
+.hljs-doctype,
+.hljs-shebang,
+.hljs-cdata {
+  color: #999;
+  font-weight: bold;
+}
+
+.hljs-deletion {
+  background: #fdd;
+}
+
+.hljs-addition {
+  background: #dfd;
+}
+
+.diff .hljs-change {
+  background: #0086b3;
+}
+
+.hljs-chunk {
+  color: #aaa;
+}
 </style>
 </head>

--- a/package.json
+++ b/package.json
@@ -26,9 +26,10 @@
   "bin": "./bin/readmetree",
   "dependencies": {
     "underscore": "~1.5.1",
-    "marked": "~0.3.2",
     "special-html": "0.0.1",
-    "glob": "~3.2.9"
+    "glob": "3.2.9",
+    "highlight.js": "8.0.0",
+    "marked": "0.3.2"
   },
   "devDependencies": {
     "d3": "~3.3.3"

--- a/readmetree.js
+++ b/readmetree.js
@@ -5,6 +5,7 @@ var exec = require('child_process').exec
 
 var _ = require('underscore')
 var marked = require('marked')
+var highlight = require('highlight.js')
 var special = require('special-html')
 var glob = require('glob')
 
@@ -20,6 +21,13 @@ var content = {
   '/': style
     + '<br><h1><a href="http://github.com/dtrejo/readmetree">readmetree</a><h3>'
 }
+
+marked.setOptions({
+  highlight: function (code) {
+    return highlight.highlightAuto(code).value
+  }
+})
+
 http.createServer(function(req, res) {
   if (!content.hasOwnProperty(req.url)) {
     return res.end('<h1>404z dude.</h1>' + content['/'])
@@ -36,7 +44,9 @@ function renderFiles(err, files) {
     return process.exit(1)
   }
 
-  files.sort(function(a, b) {
+  var fileCount = files.length
+
+  files = files.sort(function(a, b) {
     var aa = path.basename(path.dirname(a)).toLowerCase()
     var bb = path.basename(path.dirname(b)).toLowerCase()
     return aa.localeCompare(bb)
@@ -47,16 +57,32 @@ function renderFiles(err, files) {
     if (shortpath.lastIndexOf(path.sep) === 0) {
       moduleName = path.basename(root)
     }
-    if (content[shortpath]) return
-    content[shortpath] =
-      style + nav +
-      special(marked(fs.readFileSync(path.resolve(root, readme), 'utf8')))
+
+    if (content[shortpath]) return --fileCount
+
     content['/'] +=
       '<br><a href="http://localhost:'+PORT+shortpath+'">'
       + moduleName + '</a>'
+    content[shortpath] = style + nav 
+
+    loadReadme(path.resolve(root, readme), shortpath, moduleName)
   })
 
-  var url = 'http://localhost:'+PORT
-  console.log(url+' is serving all your readmes')
-  exec('open '+url)
+  function loadReadme(readme, shortpath, name) {
+    fs.readFile(readme, 'utf8', render)
+
+    function render(err, contents) {
+      marked(contents, addReadme)
+
+      function addReadme(err, html) {
+        content[shortpath] += html
+
+        if (--fileCount === 0) {
+          var url = 'http://localhost:'+PORT
+          console.log(url+' is serving all your readmes')
+          exec('open '+url)
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Alright! So, I tried a few different methods to accomplish this. Using brucedown takes a whopping 15-20 seconds (or sometimes more) to render. It also seems to hog system resources during that time (on a 2013 MBP I experience lag). I have opted instead to use marked + highlight.js to emulate github syntax highlighting. The only downside that I have seen is _this_ method doesn't render code comments correctly (or at least not how github does it). If you would prefer, however, I will use the other method.
